### PR TITLE
Fix misspellings in code which caused errors

### DIFF
--- a/src/all.js
+++ b/src/all.js
@@ -98,7 +98,7 @@ class AllBot {
 
   respondToViewBlacklist(res) {
     // Raw blacklist
-    if (res.match[1]) return res.send(JSON.strinify(this.blacklist));
+    if (res.match[1]) return res.send(JSON.stringify(this.blacklist));
 
     const blacklistNames = this.blacklist.map(
       user => this.getUserById(id).name
@@ -113,7 +113,7 @@ class AllBot {
 
     if (!user) return res.send(`Could not find a user with the name ${target}`);
 
-    conosle.log(`Blacklisting ${target}, ${user.user_id}`);
+    console.log(`Blacklisting ${target}, ${user.user_id}`);
     this.addToBlacklist(user.user_id);
     res.send(`Blacklisted ${target} successfully.`);
   }


### PR DESCRIPTION
The misspelling of `console` and `stringify` made it so that users could not use "blacklist" or "view raw blacklist".  
Error when using "blacklist" command:
![blacklisterror](https://user-images.githubusercontent.com/6393711/46573520-3d743400-c95c-11e8-9bbe-39093c8afdfe.png)
Error when using "view raw blacklist" command:
![viewrawblackisterror](https://user-images.githubusercontent.com/6393711/46573522-482ec900-c95c-11e8-975f-10a0f10cf71d.png)
Logs after fix was applied:
![blacklistsuccessful](https://user-images.githubusercontent.com/6393711/46573528-57ae1200-c95c-11e8-86db-253d8378468f.png)
